### PR TITLE
Missing abstract method in ConfigForm

### DIFF
--- a/src/Form/ConfigForm.php
+++ b/src/Form/ConfigForm.php
@@ -29,4 +29,8 @@ class ConfigForm extends ConfigFormBase {
     $config->set('default_count', $form_state->getValue('default_count'));
     $config->save();
   }
+
+  public function getEditableConfigNames() {
+    return ['hugs.settings'];
+  }
 }


### PR DESCRIPTION
```
Fatal error: Class Drupal\hugs\Form\ConfigForm contains 1 abstract method and must therefore be
declared abstract or implement the remaining methods 
(Drupal\Core\Form\ConfigFormBase::getEditableConfigNames) in 
C:\git\web\code\src\modules\custom\hugs\src\Form\ConfigForm.php on line 8
```

Added (on best guess):

  public function getEditableConfigNames() {
    return ['hugs.settings'];
  }
